### PR TITLE
feat: warn when npm account has 2FA disabled

### DIFF
--- a/.bumpy/detect-missing-2fa.md
+++ b/.bumpy/detect-missing-2fa.md
@@ -1,0 +1,5 @@
+---
+fledgling: patch
+---
+
+Warn up front when your npm account has 2FA disabled, instead of failing every claim with a raw 403.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,9 +3,10 @@ import { cli } from 'gunshi';
 import pc from 'picocolors';
 import { maybeHandleCompletion } from './completion.js';
 import { findWorkspaceRoot, discoverPackages, detectRepo } from './workspace.js';
-import { npmWhoami, npmTwoFactorStatus, checkNpmVersion } from './npm.js';
+import { npmWhoami, checkNpmVersion } from './npm.js';
 import { resolveTargets, processTarget, summarize, validateTrustSettings, buildSettings, applyIgnore, type Reporter } from './core.js';
 import { loadConfig } from './config.js';
+import { warnIfTwoFactorDisabled } from './ui.js';
 import { runWizard } from './interactive.js';
 import { runInit } from './init.js';
 import { runSync } from './sync.js';
@@ -70,14 +71,7 @@ function runPlain(values: Record<string, any>, selectors: string[]): number {
   }
   // npm requires 2FA (or a bypass-2FA token) to publish; warn (don't stop) so a disabled
   // account gets a clear heads-up instead of a raw 403 on the first claim.
-  if (!dryRun && npmTwoFactorStatus(settings.registry) === 'disabled') {
-    console.error(
-      pc.yellow(
-        "Warning: your npm account doesn't have 2FA enabled — npm requires it to publish, so claims will fail with a 403.\n" +
-          'Enable it at https://www.npmjs.com/settings/~/profile (or use a granular access token with "bypass 2FA").',
-      ),
-    );
-  }
+  if (!dryRun) warnIfTwoFactorDisabled(settings.registry, m => console.error(m));
   // Trusted publishing needs 2FA. Interactively (a TTY), npm prompts for it itself —
   // a browser approval shared across the run. Non-interactively (CI / piped) it can't
   // prompt, so pass --otp; npm surfaces a clear error during the operation otherwise.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,10 +3,10 @@ import { cli } from 'gunshi';
 import pc from 'picocolors';
 import { maybeHandleCompletion } from './completion.js';
 import { findWorkspaceRoot, discoverPackages, detectRepo } from './workspace.js';
-import { npmWhoami, checkNpmVersion } from './npm.js';
+import { npmAuthCheck, checkNpmVersion } from './npm.js';
 import { resolveTargets, processTarget, summarize, validateTrustSettings, buildSettings, applyIgnore, type Reporter } from './core.js';
 import { loadConfig } from './config.js';
-import { warnIfTwoFactorDisabled } from './ui.js';
+import { twoFactorDisabledWarning } from './ui.js';
 import { runWizard } from './interactive.js';
 import { runInit } from './init.js';
 import { runSync } from './sync.js';
@@ -65,13 +65,16 @@ function runPlain(values: Record<string, any>, selectors: string[]): number {
     console.error(pc.red(trustError));
     return 1;
   }
-  if (!dryRun && !npmWhoami(settings.registry)) {
-    console.error(pc.red('Not logged in to npm. Run `npm login` (with 2FA) and retry.'));
-    return 1;
+  // Only the apply path (`--yes`) hits npm. Require login, and warn (don't stop) on a
+  // disabled-2FA account so it gets a clear heads-up instead of a raw 403 on first claim.
+  if (!dryRun) {
+    const auth = npmAuthCheck(settings.registry);
+    if (!auth.who) {
+      console.error(pc.red('Not logged in to npm. Run `npm login` (with 2FA) and retry.'));
+      return 1;
+    }
+    if (auth.twoFactorDisabled) console.error(twoFactorDisabledWarning);
   }
-  // npm requires 2FA (or a bypass-2FA token) to publish; warn (don't stop) so a disabled
-  // account gets a clear heads-up instead of a raw 403 on the first claim.
-  if (!dryRun) warnIfTwoFactorDisabled(settings.registry, m => console.error(m));
   // Trusted publishing needs 2FA. Interactively (a TTY), npm prompts for it itself —
   // a browser approval shared across the run. Non-interactively (CI / piped) it can't
   // prompt, so pass --otp; npm surfaces a clear error during the operation otherwise.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { cli } from 'gunshi';
 import pc from 'picocolors';
 import { maybeHandleCompletion } from './completion.js';
 import { findWorkspaceRoot, discoverPackages, detectRepo } from './workspace.js';
-import { npmWhoami, checkNpmVersion } from './npm.js';
+import { npmWhoami, npmTwoFactorStatus, checkNpmVersion } from './npm.js';
 import { resolveTargets, processTarget, summarize, validateTrustSettings, buildSettings, applyIgnore, type Reporter } from './core.js';
 import { loadConfig } from './config.js';
 import { runWizard } from './interactive.js';
@@ -67,6 +67,16 @@ function runPlain(values: Record<string, any>, selectors: string[]): number {
   if (!dryRun && !npmWhoami(settings.registry)) {
     console.error(pc.red('Not logged in to npm. Run `npm login` (with 2FA) and retry.'));
     return 1;
+  }
+  // npm requires 2FA (or a bypass-2FA token) to publish; warn (don't stop) so a disabled
+  // account gets a clear heads-up instead of a raw 403 on the first claim.
+  if (!dryRun && npmTwoFactorStatus(settings.registry) === 'disabled') {
+    console.error(
+      pc.yellow(
+        "Warning: your npm account doesn't have 2FA enabled — npm requires it to publish, so claims will fail with a 403.\n" +
+          'Enable it at https://www.npmjs.com/settings/~/profile (or use a granular access token with "bypass 2FA").',
+      ),
+    );
   }
   // Trusted publishing needs 2FA. Interactively (a TTY), npm prompts for it itself —
   // a browser approval shared across the run. Non-interactively (CI / piped) it can't

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -1,7 +1,7 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { findWorkspaceRoot, discoverPackages, detectRepo, type Pkg } from './workspace.js';
-import { npmWhoami, publishedNames, warmNpmAuth, validatePackageName, isNameAvailable } from './npm.js';
+import { npmAuthCheck, publishedNames, warmNpmAuth, validatePackageName, isNameAvailable } from './npm.js';
 import {
   resolveTargets,
   processTarget,
@@ -14,7 +14,7 @@ import {
   type TrustView,
 } from './core.js';
 import { loadConfig, type Permission, type Provider } from './config.js';
-import { hatchSpinner, hatchIntro, cmd, otpBoxReminder, warnIfTwoFactorDisabled, note } from './ui.js';
+import { hatchSpinner, hatchIntro, cmd, otpBoxReminder, reportNpmAuth, note } from './ui.js';
 
 const cancelled = (v: unknown): boolean => p.isCancel(v);
 
@@ -41,16 +41,12 @@ export async function runWizard(values: Record<string, any>, selectors: string[]
   }
 
   // Check login up front (per-registry) so we can flag it before any prompts. We don't
-  // hard-stop — without a login we still walk through and show a dry-run preview.
-  const who = npmWhoami(registry);
-  if (who) {
-    p.log.info(`Logged in to npm as ${pc.green(who)}`);
-    // npm requires 2FA (or a bypass-2FA token) to publish — catch a disabled account here
-    // rather than letting every claim 403. A warning, not a stop: token users read 'unknown'.
-    warnIfTwoFactorDisabled(registry, m => p.log.warn(m));
-  } else {
-    p.log.warn(pc.yellow('Not logged in to npm — run `npm login` (with 2FA) to apply. This run will be a dry run.'));
-  }
+  // hard-stop — without a login we still walk through and show a dry-run preview. A
+  // logged-in report also flags a disabled-2FA account (which would 403 at claim time).
+  const auth = npmAuthCheck(registry);
+  const who = auth.who;
+  if (who) reportNpmAuth(auth);
+  else p.log.warn(pc.yellow('Not logged in to npm — run `npm login` (with 2FA) to apply. This run will be a dry run.'));
 
   // --- choose targets ---
   const onlyTrust = !!values['skip-publish'];

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -1,7 +1,7 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { findWorkspaceRoot, discoverPackages, detectRepo, type Pkg } from './workspace.js';
-import { npmWhoami, publishedNames, warmNpmAuth, validatePackageName, isNameAvailable } from './npm.js';
+import { npmWhoami, npmTwoFactorStatus, publishedNames, warmNpmAuth, validatePackageName, isNameAvailable } from './npm.js';
 import {
   resolveTargets,
   processTarget,
@@ -43,8 +43,21 @@ export async function runWizard(values: Record<string, any>, selectors: string[]
   // Check login up front (per-registry) so we can flag it before any prompts. We don't
   // hard-stop — without a login we still walk through and show a dry-run preview.
   const who = npmWhoami(registry);
-  if (who) p.log.info(`Logged in to npm as ${pc.green(who)}`);
-  else p.log.warn(pc.yellow('Not logged in to npm — run `npm login` (with 2FA) to apply. This run will be a dry run.'));
+  if (who) {
+    p.log.info(`Logged in to npm as ${pc.green(who)}`);
+    // npm requires 2FA (or a bypass-2FA token) to publish — catch a disabled account here
+    // rather than letting every claim 403. A warning, not a stop: token users read 'unknown'.
+    if (npmTwoFactorStatus(registry) === 'disabled') {
+      p.log.warn(
+        pc.yellow(
+          `Your npm account doesn't have 2FA enabled — npm requires it to publish, so claims will fail with a 403.\n` +
+            `Enable it at ${pc.underline('https://www.npmjs.com/settings/~/profile')} (or authenticate with a granular access token that has "bypass 2FA").`,
+        ),
+      );
+    }
+  } else {
+    p.log.warn(pc.yellow('Not logged in to npm — run `npm login` (with 2FA) to apply. This run will be a dry run.'));
+  }
 
   // --- choose targets ---
   const onlyTrust = !!values['skip-publish'];

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -1,7 +1,7 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { findWorkspaceRoot, discoverPackages, detectRepo, type Pkg } from './workspace.js';
-import { npmWhoami, npmTwoFactorStatus, publishedNames, warmNpmAuth, validatePackageName, isNameAvailable } from './npm.js';
+import { npmWhoami, publishedNames, warmNpmAuth, validatePackageName, isNameAvailable } from './npm.js';
 import {
   resolveTargets,
   processTarget,
@@ -14,7 +14,7 @@ import {
   type TrustView,
 } from './core.js';
 import { loadConfig, type Permission, type Provider } from './config.js';
-import { hatchSpinner, hatchIntro, cmd, otpBoxReminder, note } from './ui.js';
+import { hatchSpinner, hatchIntro, cmd, otpBoxReminder, warnIfTwoFactorDisabled, note } from './ui.js';
 
 const cancelled = (v: unknown): boolean => p.isCancel(v);
 
@@ -47,14 +47,7 @@ export async function runWizard(values: Record<string, any>, selectors: string[]
     p.log.info(`Logged in to npm as ${pc.green(who)}`);
     // npm requires 2FA (or a bypass-2FA token) to publish — catch a disabled account here
     // rather than letting every claim 403. A warning, not a stop: token users read 'unknown'.
-    if (npmTwoFactorStatus(registry) === 'disabled') {
-      p.log.warn(
-        pc.yellow(
-          `Your npm account doesn't have 2FA enabled — npm requires it to publish, so claims will fail with a 403.\n` +
-            `Enable it at ${pc.underline('https://www.npmjs.com/settings/~/profile')} (or authenticate with a granular access token that has "bypass 2FA").`,
-        ),
-      );
-    }
+    warnIfTwoFactorDisabled(registry, m => p.log.warn(m));
   } else {
     p.log.warn(pc.yellow('Not logged in to npm — run `npm login` (with 2FA) to apply. This run will be a dry run.'));
   }

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -73,6 +73,32 @@ export function npmWhoami(registry?: string): string | null {
   }
 }
 
+/**
+ * The account's 2FA status on `registry`. npm now *requires* 2FA (or a granular access
+ * token with "bypass 2FA") to publish, and fledgling's flow leans on npm's interactive
+ * 2FA approval — so a disabled account will 403 at claim time. We surface this up front.
+ *
+ * `'disabled'` = 2FA is off (publishing will fail); `'enabled'` = fine; `'unknown'` =
+ * couldn't tell (not logged in, token auth where the profile read fails, offline, …) —
+ * callers should stay quiet then, since token users can publish with `tfa` unreadable.
+ */
+export function npmTwoFactorStatus(registry?: string): 'enabled' | 'disabled' | 'unknown' {
+  try {
+    const out = execFileSync('npm', withRegistry(['profile', 'get', '--json'], registry), {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    // `npm profile get --json` emits the raw server profile: `tfa` is an object with a
+    // `mode` when 2FA is on, and false/null/absent when off.
+    const tfa = JSON.parse(out)?.tfa;
+    if (tfa && typeof tfa === 'object' && tfa.mode) return 'enabled';
+    if (tfa === false || tfa == null) return 'disabled';
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
 /** Minimum npm fledgling needs — `npm trust` + OIDC/staged publishing landed here. */
 export const MIN_NPM = '11.15.0';
 

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -99,6 +99,24 @@ export function npmTwoFactorStatus(registry?: string): 'enabled' | 'disabled' | 
   }
 }
 
+/** The result of an npm auth preflight — who we are, and whether 2FA will block publishing. */
+export interface NpmAuth {
+  /** Logged-in npm user for `registry`, or null if not logged in. */
+  who: string | null;
+  /** Logged in *and* the account has 2FA off (publishing/trust will 403). */
+  twoFactorDisabled: boolean;
+}
+
+/**
+ * One npm auth preflight, shared by every command: who am I on `registry`, and is 2FA
+ * missing? 2FA is only probed when logged in (a `profile get` while logged out is noise).
+ * Callers decide the *policy* around the result — soft-warn, or hard-stop.
+ */
+export function npmAuthCheck(registry?: string): NpmAuth {
+  const who = npmWhoami(registry);
+  return { who, twoFactorDisabled: !!who && npmTwoFactorStatus(registry) === 'disabled' };
+}
+
 /** Minimum npm fledgling needs — `npm trust` + OIDC/staged publishing landed here. */
 export const MIN_NPM = '11.15.0';
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,7 +1,7 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { findWorkspaceRoot, discoverPackages, detectRepo, type Pkg } from './workspace.js';
-import { npmWhoami, listTrust, configureTrust, revokeTrust, warmNpmAuth, publishedNames } from './npm.js';
+import { npmWhoami, npmTwoFactorStatus, listTrust, configureTrust, revokeTrust, warmNpmAuth, publishedNames } from './npm.js';
 import {
   resolveTargets,
   validateTrustSettings,
@@ -37,6 +37,15 @@ export async function runSync(values: Record<string, any>, selectors: string[]):
     return 1;
   }
   p.log.info(`Logged in to npm as ${pc.green(who)}`);
+  // Trust writes need 2FA — warn (don't stop) so a disabled account isn't surprised by a 403.
+  if (npmTwoFactorStatus(registry) === 'disabled') {
+    p.log.warn(
+      pc.yellow(
+        `Your npm account doesn't have 2FA enabled — npm requires it to update trusted publishing.\n` +
+          `Enable it at ${pc.underline('https://www.npmjs.com/settings/~/profile')} (or authenticate with a granular access token that has "bypass 2FA").`,
+      ),
+    );
+  }
 
   const discovered = applyIgnore(discoverPackages(root), config.ignore);
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,7 +1,7 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { findWorkspaceRoot, discoverPackages, detectRepo, type Pkg } from './workspace.js';
-import { npmWhoami, npmTwoFactorStatus, listTrust, configureTrust, revokeTrust, warmNpmAuth, publishedNames } from './npm.js';
+import { npmWhoami, listTrust, configureTrust, revokeTrust, warmNpmAuth, publishedNames } from './npm.js';
 import {
   resolveTargets,
   validateTrustSettings,
@@ -13,7 +13,7 @@ import {
   applyIgnore,
 } from './core.js';
 import { loadConfig } from './config.js';
-import { hatchSpinner, hatchIntro, otpBoxReminder, note } from './ui.js';
+import { hatchSpinner, hatchIntro, otpBoxReminder, warnIfTwoFactorDisabled, note } from './ui.js';
 
 /**
  * `fledgling sync` — reconcile trusted publishing across the workspace.
@@ -38,14 +38,7 @@ export async function runSync(values: Record<string, any>, selectors: string[]):
   }
   p.log.info(`Logged in to npm as ${pc.green(who)}`);
   // Trust writes need 2FA — warn (don't stop) so a disabled account isn't surprised by a 403.
-  if (npmTwoFactorStatus(registry) === 'disabled') {
-    p.log.warn(
-      pc.yellow(
-        `Your npm account doesn't have 2FA enabled — npm requires it to update trusted publishing.\n` +
-          `Enable it at ${pc.underline('https://www.npmjs.com/settings/~/profile')} (or authenticate with a granular access token that has "bypass 2FA").`,
-      ),
-    );
-  }
+  warnIfTwoFactorDisabled(registry, m => p.log.warn(m));
 
   const discovered = applyIgnore(discoverPackages(root), config.ignore);
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,7 +1,7 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { findWorkspaceRoot, discoverPackages, detectRepo, type Pkg } from './workspace.js';
-import { npmWhoami, listTrust, configureTrust, revokeTrust, warmNpmAuth, publishedNames } from './npm.js';
+import { npmAuthCheck, listTrust, configureTrust, revokeTrust, warmNpmAuth, publishedNames } from './npm.js';
 import {
   resolveTargets,
   validateTrustSettings,
@@ -13,7 +13,7 @@ import {
   applyIgnore,
 } from './core.js';
 import { loadConfig } from './config.js';
-import { hatchSpinner, hatchIntro, otpBoxReminder, warnIfTwoFactorDisabled, note } from './ui.js';
+import { hatchSpinner, hatchIntro, otpBoxReminder, reportNpmAuth, note } from './ui.js';
 
 /**
  * `fledgling sync` — reconcile trusted publishing across the workspace.
@@ -31,14 +31,13 @@ export async function runSync(values: Record<string, any>, selectors: string[]):
   // sync reads and writes live trust config, so it needs to be logged in — check up
   // front (per-registry) before any scanning, so we fail fast with a clear message.
   const registry = values.registry ?? config.registry;
-  const who = npmWhoami(registry);
-  if (!who) {
+  const auth = npmAuthCheck(registry);
+  if (!auth.who) {
     p.cancel(pc.red('Not logged in to npm. Run `npm login` (with 2FA) and retry.'));
     return 1;
   }
-  p.log.info(`Logged in to npm as ${pc.green(who)}`);
-  // Trust writes need 2FA — warn (don't stop) so a disabled account isn't surprised by a 403.
-  warnIfTwoFactorDisabled(registry, m => p.log.warn(m));
+  // Reports "logged in as…" and warns if 2FA is off (trust writes would 403).
+  reportNpmAuth(auth);
 
   const discovered = applyIgnore(discoverPackages(root), config.ignore);
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,6 +1,7 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { setTimeout as sleep } from 'node:timers/promises';
+import { npmTwoFactorStatus } from './npm.js';
 
 const BAR_START = '┌'; // ┌  (matches clack's intro)
 
@@ -19,6 +20,21 @@ export const note = (message: string, title?: string): void =>
 export const otpBoxReminder =
   `npm will open your browser to approve 2FA — tick ${pc.bold(`"don't ask again for 5 minutes"`)} ` +
   `so it won't prompt again for every package.`;
+
+/** Shown when the logged-in npm account has 2FA off — publishing/trust will 403 without it. */
+const twoFactorDisabledWarning = pc.yellow(
+  `Your npm account doesn't have 2FA enabled — npm requires it to publish/configure trust, so this will fail with a 403.\n` +
+    `Enable it at ${pc.underline('https://www.npmjs.com/settings/~/profile')} (or authenticate with a granular access token that has "bypass 2FA").`,
+);
+
+/**
+ * If the account's 2FA is disabled, emit the warning via `warn` (whatever logger the
+ * caller uses — clack, console, …). A no-op when 2FA is on or can't be read, so callers
+ * just decide *when* to check (logged in? applying?) — not what to say. See `npmTwoFactorStatus`.
+ */
+export function warnIfTwoFactorDisabled(registry: string | undefined, warn: (msg: string) => void): void {
+  if (npmTwoFactorStatus(registry) === 'disabled') warn(twoFactorDisabledWarning);
+}
 
 /** A spinner that hatches: 🥚 → 🐣 → 🐥. */
 export const hatchSpinner = () => p.spinner({ frames: ['🥚', '🥚', '🐣', '🐣', '🐥'], delay: 180 });

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,7 +1,7 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import { setTimeout as sleep } from 'node:timers/promises';
-import { npmTwoFactorStatus } from './npm.js';
+import type { NpmAuth } from './npm.js';
 
 const BAR_START = '┌'; // ┌  (matches clack's intro)
 
@@ -22,18 +22,20 @@ export const otpBoxReminder =
   `so it won't prompt again for every package.`;
 
 /** Shown when the logged-in npm account has 2FA off — publishing/trust will 403 without it. */
-const twoFactorDisabledWarning = pc.yellow(
+export const twoFactorDisabledWarning = pc.yellow(
   `Your npm account doesn't have 2FA enabled — npm requires it to publish/configure trust, so this will fail with a 403.\n` +
     `Enable it at ${pc.underline('https://www.npmjs.com/settings/~/profile')} (or authenticate with a granular access token that has "bypass 2FA").`,
 );
 
 /**
- * If the account's 2FA is disabled, emit the warning via `warn` (whatever logger the
- * caller uses — clack, console, …). A no-op when 2FA is on or can't be read, so callers
- * just decide *when* to check (logged in? applying?) — not what to say. See `npmTwoFactorStatus`.
+ * Report a logged-in npm session the clack way (used by the wizard and `sync`): the
+ * "logged in as…" line plus a 2FA heads-up when it's off. No-op if not logged in — the
+ * caller owns that branch, since dry-run and hard-stop paths word it differently.
  */
-export function warnIfTwoFactorDisabled(registry: string | undefined, warn: (msg: string) => void): void {
-  if (npmTwoFactorStatus(registry) === 'disabled') warn(twoFactorDisabledWarning);
+export function reportNpmAuth({ who, twoFactorDisabled }: NpmAuth): void {
+  if (!who) return;
+  p.log.info(`Logged in to npm as ${pc.green(who)}`);
+  if (twoFactorDisabled) p.log.warn(twoFactorDisabledWarning);
 }
 
 /** A spinner that hatches: 🥚 → 🐣 → 🐥. */


### PR DESCRIPTION
## Why

A user tried fledgling with an npm account that had **2FA disabled** and every claim failed with a raw `E403`:

> 403 Forbidden - PUT ... Two-factor authentication or granular access token with bypass 2fa enabled is required to publish packages.

npm now requires 2FA (or a granular access token with "bypass 2FA") to publish, and fledgling's flow relies on npm's interactive browser-2FA approval — so a no-2FA account can't publish at all, and only finds out one ugly 403 at a time.

## What

Detect the situation up front and warn clearly, before walking the whole wizard.

- `npmTwoFactorStatus(registry)` in `src/npm.ts` — reads `npm profile get --json`, whose `tfa` field is an object with a `mode` when enabled and `false`/absent when disabled. Returns `'enabled' | 'disabled' | 'unknown'`.
- Warning wired into all three flows that need publish/trust auth: the interactive wizard (`src/interactive.ts`), the non-interactive `--yes` path (`src/cli.ts`), and `sync` (`src/sync.ts`).

## Design calls

- **Warn, don't hard-stop.** A user authenticated with a granular bypass-2FA token can publish fine while `profile get` reports `tfa: false` or fails outright — those resolve to `'unknown'` and stay silent. Only a confirmed `'disabled'` warns, so there are no false blocks.
- **Only when logged in.** Skips the extra `profile get` round-trip on the not-logged-in / dry-run path, which is already warned separately.

Warning text points to `npmjs.com/settings/~/profile` and mentions the bypass-2FA token alternative.