### PR TITLE
fix: skip trust for --new names when no repo, instead of erroring

### DIFF
--- a/.bumpy/new-name-skip-trust-without-repo.md
+++ b/.bumpy/new-name-skip-trust-without-repo.md
@@ -1,0 +1,5 @@
+---
+fledgling: patch
+---
+
+When claiming a brand-new name with `--new` and no repo can be resolved, skip trusted publishing (with a note) instead of erroring out the whole run — you can wire it up later with `fledgling sync`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,15 @@ function runPlain(values: Record<string, any>, selectors: string[]): number {
 
   const dryRun = !values.yes;
   const settings = buildSettings(values, config, repo, dryRun);
+  // Trusted publishing only makes sense once a package lives in a repo/CI. A brand-new
+  // name isn't necessarily there yet — so if we can't resolve a trust config for an
+  // all-new claim, skip trust (with a note) rather than blocking the name claim. Once
+  // it's in a repo, `fledgling sync` (or a passed --repo) wires up trust.
+  const allNew = resolved.targets.every(t => t.isNew);
+  if (!settings.skipTrust && allNew && validateTrustSettings(settings)) {
+    console.log(pc.dim('No repo/CI context for a new name — skipping trusted publishing. Run `fledgling sync` once it lives in a repo.'));
+    settings.skipTrust = true;
+  }
   const trustError = validateTrustSettings(settings);
   if (trustError) {
     console.error(pc.red(trustError));


### PR DESCRIPTION
## Context

Follow-up to the discussion on whether `--new` should offer trusted publishing at all. Conclusion: **keep it** — claiming a name *and* wiring up OIDC in one shot is fledgling's core promise, and the common `--new` case is bootstrapping a package into a repo you already have (fresh repo, or new package in a monorepo). Fully disabling trust for `--new` would amputate that.

The real wart was narrower: the **non-interactive** `--new` path coupled the name claim to trust setup. For an all-new name with no resolvable repo, `validateTrustSettings` hard-failed the entire run —

```
Cannot determine the repo. Pass --repo <owner/repo> (or --skip-trust).
```

— so you couldn't even claim the name without also sorting out trust.

## Change

In `runPlain` ([src/cli.ts](src/cli.ts)): for an **all-new** claim where trust config can't be resolved, skip trusted publishing with a note instead of erroring:

```
No repo/CI context for a new name — skipping trusted publishing. Run `fledgling sync` once it lives in a repo.
```

The name is still claimed. Once the package lives in a repo, `fledgling sync` (or passing `--repo`) sets trust up.

## Scope / what's unchanged

- **Bootstrap-into-a-repo still works**: if a git origin is detected or `--repo` is passed, trust is configured exactly as before.
- **Only all-new targets** downgrade — a mixed run (a `--new` name alongside a real workspace package) still hard-errors on a missing repo, since those packages genuinely want trust.
- **Interactive wizard unchanged**: it was already correct (trust is opt-in, default No, and prompts for the repo if you opt in).

## Verified

- No-repo dir, `add <name> --new --dry-run` → prints the skip note, claims the name, `trusted 0 (skipped 0)`.
- Repo dir (git origin present), same command → keeps trust setup against the detected repo, no skip note.