### PR TITLE
fix: move lefthook install from postinstall to prepare

### DIFF
--- a/.bumpy/fix-postinstall-breaking-installs.md
+++ b/.bumpy/fix-postinstall-breaking-installs.md
@@ -1,0 +1,5 @@
+---
+fledgling: patch
+---
+
+Fix `npx fledgling` (and every other install) doing nothing at all. The `postinstall: lefthook install` script ran on end-user installs, but `lefthook` is a devDependency and isn't there — so the script exited 127, npm aborted the install before ever reaching the `bin`, and since npm swallows script output at the default loglevel you got zero output and no error. Moved git-hook installation to `prepare`, which runs in the repo and before publish but not for consumers installing from the registry.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dev": "tsdown --watch",
     "typecheck": "tsc --noEmit",
     "start": "node dist/cli.mjs",
-    "postinstall": "lefthook install"
+    "prepare": "lefthook install || true"
   },
   "dependencies": {
     "@clack/prompts": "^1.5.1",


### PR DESCRIPTION
## The bug

`npx fledgling@latest` produces **nothing** — zero bytes on stdout and stderr, exit 127.

`package.json` had `"postinstall": "lefthook install"`, but `lefthook` is a **devDependency**. On a consumer install only runtime deps are present, so:

1. `lefthook` isn't found → postinstall exits 127
2. npm aborts the install → the `bin` is **never reached**
3. npm swallows script output at the default loglevel → no visible error

From `npx --loglevel verbose`:

```
npm info run fledgling@1.2.0 postinstall node_modules/fledgling lefthook install
npm info run fledgling@1.2.0 postinstall { code: 127, signal: null }
npm verbose exit 127
```

Introduced in fe9f8e5 and shipped in 1.2.0, so **every consumer install of 1.2.0 is broken**, not just `npx`.

## The fix

`prepare` is the correct lifecycle hook for git-hook installation: it runs on local install in the repo and before publish, but **not** for consumers installing from a registry tarball.

The `|| true` guard is deliberate — `prepare` also fires on `npm publish` during the release job, and a git-hook install should never be able to fail a release (e.g. if no `.git` is present).

## Verification

Packed a tarball from this branch and installed it as a consumer would:

- install exits **0** (was 127)
- `fledgling --version` → `1.2.0`
- `fledgling --help` prints the full command list
- no-arg run in a non-git dir prints `Cannot determine the repo. Pass --repo <owner/repo>...` and exits 1 — real output, correct for that directory

Local hooks still work: `bun run prepare` → `sync hooks: ✔️(pre-push)`, `.git/hooks/pre-push` intact. The pre-push hook ran on this very push.

## Scope

Deliberately just the one-line `scripts` change plus the bump file. Unrelated in-progress pypi work was left out of this branch.